### PR TITLE
Submit tweet button not disabled when tweet character count is 0

### DIFF
--- a/app/src/main/java/com/twitter/university/android/yamba/TweetFragment.java
+++ b/app/src/main/java/com/twitter/university/android/yamba/TweetFragment.java
@@ -85,6 +85,8 @@ public class TweetFragment extends Fragment {
             }
         );
 
+        updateCount();
+
         return v;
     }
 


### PR DESCRIPTION
The event to check whether the submit tweet button should be enabled isn't being called when the TweetFragment is created.